### PR TITLE
Add a note on compiling .eliom files with 3rd-party syntax extensions

### DIFF
--- a/src/rest.wiki
+++ b/src/rest.wiki
@@ -107,7 +107,7 @@ In order to successfully build this tutorial's source code, your
 {{{Makefile.options}}} must contain the following settings:
 <<code language="makefile"|
 # OCamlfind packages for the server
-SERVER_PACKAGES := deriving-yojson.syntax deriving-yojson yojson
+SERVER_PACKAGES := deriving-yojson.syntax deriving-yojson
 # OCamlfind packages for the client
 CLIENT_PACKAGES := deriving-yojson.syntax
 >>


### PR DESCRIPTION
This pr follows up the ticket https://github.com/ocsigen/eliom/issues/154
