### PR TITLE
Tuto widgets second step

### DIFF
--- a/src/tutowidgets.wiki
+++ b/src/tutowidgets.wiki
@@ -137,7 +137,7 @@ let%client switch_visibility elt =
   else
     elt##.classList##add (Js.string "hidden")
 
-let%client mywidget s1 s2 = Elim_content.Html.D.(
+let%client mywidget s1 s2 = Eliom_content.Html.D.(
   let button  = div ~a:[a_class ["button"]] [pcdata s1] in
   let content = div ~a:[a_class ["content"]] [pcdata s2] in
   Lwt.async (fun () ->

--- a/src/tutowidgets.wiki
+++ b/src/tutowidgets.wiki
@@ -130,14 +130,14 @@ To make the widget work, we must bind the click event.
 Replace function {{{mywidget}}} by the following lines:
 
 <<code language="ocaml" |
-let%client switch_visibility elt =
+let switch_visibility elt =
   let elt = Eliom_content.Html.To_dom.of_element elt in
   if Js.to_bool (elt##.classList##contains (Js.string "hidden")) then
     elt##.classList##remove (Js.string "hidden")
   else
     elt##.classList##add (Js.string "hidden")
 
-let%client mywidget s1 s2 = Eliom_content.Html.D.(
+let mywidget s1 s2 = Eliom_content.Html.D.(
   let button  = div ~a:[a_class ["button"]] [pcdata s1] in
   let content = div ~a:[a_class ["content"]] [pcdata s2] in
   Lwt.async (fun () ->

--- a/src/tutowidgets.wiki
+++ b/src/tutowidgets.wiki
@@ -141,7 +141,7 @@ let%client mywidget s1 s2 = Eliom_content.Html.D.(
   let button  = div ~a:[a_class ["button"]] [pcdata s1] in
   let content = div ~a:[a_class ["content"]] [pcdata s2] in
   Lwt.async (fun () ->
-    Lwt_js_events.clicks (To_dom.of_element button)
+    Lwt_js_events.clicks (Eliom_content.Html.To_dom.of_element button)
       (fun _ _ -> switch_visibility content; Lwt.return ()));
   div ~a:[a_class ["mywidget"]] [button; content]
 )


### PR DESCRIPTION
This PR fix : 
*  one typo,
*  an `Unbound module To_dom` error with the command `make test.byte`.
*  and I modified the code to add in the second step in order to make it work. The final code I have is the following :


```ocaml
module Ex_app =
  Eliom_registration.App (struct
    let application_name = "ex"
    let global_data_path = None
  end)

let _ = Eliom_content.Html.D.(
  Ex_app.create
    ~path:(Eliom_service.Path [""])
    ~meth:(Eliom_service.Get Eliom_parameter.unit)
    (fun () () ->
       Lwt.return
         (Eliom_tools.D.html ~title:"tutowidgets" ~css:[["css"; "ex.css"]]
            (body [h2 [pcdata "Welcome to Ocsigen!"]])))
)

[%%client
let switch_visibility elt =
  let elt = Eliom_content.Html.To_dom.of_element elt in
  if Js.to_bool (elt##.classList##contains (Js.string "hidden")) then
    elt##.classList##remove (Js.string "hidden")
  else
    elt##.classList##add (Js.string "hidden")

let mywidget s1 s2 = Eliom_content.Html.D.(
  let button  = div ~a:[a_class ["button"]] [pcdata s1] in
  let content = div ~a:[a_class ["content"]] [pcdata s2] in
  Lwt.async (fun () ->
    Lwt_js_events.clicks (Eliom_content.Html.To_dom.of_element button)
      (fun _ _ -> switch_visibility content; Lwt.return ()));
  div ~a:[a_class ["mywidget"]] [button; content]
)

let _ =
  let%lwt _ = Lwt_js_events.onload () in
  Dom.appendChild
    (Dom_html.document##.body)
    (Eliom_content.Html.To_dom.of_element (mywidget "Click me" "Hello!"));
  Lwt.return ()
]
```

I am not sure if it is good, but it was the only way for me to make it work.

Regards. 